### PR TITLE
Fix files path

### DIFF
--- a/lib/isic/search.rb
+++ b/lib/isic/search.rb
@@ -2,9 +2,9 @@ class Isic
   class Search
 
     FILES = {
-      en: 'files/ISIC_Rev_4_english_structure.txt',
-      es: 'files/ISIC_Rev_4_spanish_structure.txt',
-      fr: 'files/ISIC_Rev_4_french_structure.txt'
+      en: File.join(File.dirname(File.expand_path(__FILE__)), '../files/ISIC_Rev_4_english_structure.txt'),
+      es: File.join(File.dirname(File.expand_path(__FILE__)), '../files/ISIC_Rev_4_spanish_structure.txt'),
+      fr: File.join(File.dirname(File.expand_path(__FILE__)), '../files/ISIC_Rev_4_french_structure.txt')
     }
 
     ENCODINGS = {

--- a/lib/isic/search.rb
+++ b/lib/isic/search.rb
@@ -2,9 +2,9 @@ class Isic
   class Search
 
     FILES = {
-      en: File.join(File.dirname(File.expand_path(__FILE__)), '../files/ISIC_Rev_4_english_structure.txt'),
-      es: File.join(File.dirname(File.expand_path(__FILE__)), '../files/ISIC_Rev_4_spanish_structure.txt'),
-      fr: File.join(File.dirname(File.expand_path(__FILE__)), '../files/ISIC_Rev_4_french_structure.txt')
+      en: File.join(File.dirname(File.expand_path(__FILE__)), '../../files/ISIC_Rev_4_english_structure.txt'),
+      es: File.join(File.dirname(File.expand_path(__FILE__)), '../../files/ISIC_Rev_4_spanish_structure.txt'),
+      fr: File.join(File.dirname(File.expand_path(__FILE__)), '../../files/ISIC_Rev_4_french_structure.txt')
     }
 
     ENCODINGS = {


### PR DESCRIPTION
I had a problem using isic in environments such as pry:

```
03:33 slack@billy:~$ pry
[1] pry(main)> gem 'isic'
=> true
[2] pry(main)> require 'isic'
=> true
[3] pry(main)> Isic::Entity.new('0891').classify
Errno::ENOENT: No such file or directory @ rb_sysopen - files/ISIC_Rev_4_english_structure.txt
from /var/lib/gems/2.1.0/gems/isic-1.0.3/lib/isic/search.rb:24:in `initialize'
```

This is because the CSV files in isic/search.rb were not fully specified.  They're now specified like this:

```
en: File.join(File.dirname(File.expand_path(__FILE__)), '../../files/ISIC_Rev_4_english_structure.txt')
```

So now isic works in pry:

```
04:04 slack@billy:~/git/isic$ pry -I lib
[1] pry(main)> gem 'isic'
=> true
[2] pry(main)> require 'isic'
=> true
[3] pry(main)> Isic::Entity.new("0891").classify
=> {:class=>{:code=>"0891", :description=>"Mining of chemical and fertilizer minerals"},
 :group=>{:code=>"089", :description=>"Mining and quarrying n.e.c."},
 :division=>{:code=>"08", :description=>"Other mining and quarrying"},
 :section=>{:code=>"B", :description=>"Mining and quarrying"}}
```

Tests are still passing.
